### PR TITLE
GetDerivedType should consider only the derived types of the provided…

### DIFF
--- a/src/client/Microsoft.Rest.ClientRuntime.Tests/Resources/Animal.cs
+++ b/src/client/Microsoft.Rest.ClientRuntime.Tests/Resources/Animal.cs
@@ -31,6 +31,13 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
     }
 
     [JsonObject("siamese")]
+    public class Martian : Alien
+    {
+        [JsonProperty("robot")]
+        public string Robot { get; set; }
+    }
+
+    [JsonObject("siamese")]
     public class Siamese : Cat
     {
         [JsonProperty("color")]

--- a/src/client/Microsoft.Rest.ClientRuntime/Serialization/PolymorphicJsonConverter.cs
+++ b/src/client/Microsoft.Rest.ClientRuntime/Serialization/PolymorphicJsonConverter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Rest.Serialization
                 throw new ArgumentNullException("baseType");
             }
             foreach (TypeInfo type in baseType.GetTypeInfo().Assembly.DefinedTypes
-                .Where(t => t.Namespace == baseType.Namespace && t != baseType.GetTypeInfo()))
+                .Where(t => t.Namespace == baseType.Namespace && t != baseType.GetTypeInfo() && t.IsSubclassOf(baseType)))
             {
                 string typeName = type.Name;
                 if (type.GetCustomAttributes<JsonObjectAttribute>().Any())


### PR DESCRIPTION
… base type (#1352)

* Update PolymorphicJsonConverter.cs

* Added PolymorphicDeserializationConsidersOnlyOwnDerivedTypes  test

This is part of the fix for the GetDerivedTypes bug where the method was
considering all the types in the Assembly for a potential derived type
(based on the discriminator value). This search has been scoped to just
the types inheriting from the base type, as part of this fix.